### PR TITLE
修复 Termux 终端 CANNOT LINK / provider 空 base_url + RAG 会话检索增强

### DIFF
--- a/apps/coomi-app/app/src/main/java/app/coomi/AuthFragment.java
+++ b/apps/coomi-app/app/src/main/java/app/coomi/AuthFragment.java
@@ -252,6 +252,13 @@ public class AuthFragment extends Fragment implements CoomiSetupActivity.StepFra
 
         String baseUrl = mBaseUrlInput.getText().toString().trim();
 
+        // 自定义 provider 没有默认 base_url，必须显式填写，否则保存会产生
+        // coomi 无法加载的配置（"provider `custom` has no base_url"）。
+        if (TextUtils.isEmpty(baseUrl) && TextUtils.isEmpty(defaultBaseUrl(mSelectedProvider))) {
+            setStatus(R.string.coomi_auth_need_base_url, R.color.coomi_danger);
+            return;
+        }
+
         setStatus(R.string.coomi_auth_saving, R.color.coomi_text_2);
 
         // Save provider + model to config

--- a/apps/coomi-app/app/src/main/java/app/coomi/CoomiConfig.java
+++ b/apps/coomi-app/app/src/main/java/app/coomi/CoomiConfig.java
@@ -81,7 +81,15 @@ public final class CoomiConfig {
             }
             if (models.length() > 0) provider.put("models", models);
             if (!provider.has("api_key")) provider.put("api_key", "");
-            if (!provider.has("base_url")) provider.put("base_url", defaultBaseUrl(providerId));
+            String resolvedBaseUrl = provider.optString("base_url", "");
+            if (TextUtils.isEmpty(resolvedBaseUrl)) resolvedBaseUrl = defaultBaseUrl(providerId);
+            if (TextUtils.isEmpty(resolvedBaseUrl)) {
+                // 自定义 provider 无默认 base_url 且未显式提供时拒绝保存：
+                // coomi 加载 providers.json 会对空 base_url 报 "provider `{id}` has no base_url"。
+                Logger.logError(LOG_TAG, "Cannot activate provider " + providerId + ": base_url is empty");
+                return false;
+            }
+            provider.put("base_url", resolvedBaseUrl);
             providers.put(providerId, provider);
             document.put("active", providerId);
             return writeConfig(document);
@@ -114,6 +122,11 @@ public final class CoomiConfig {
             }
             provider.put("api_key", apiKey.trim());
             String resolvedBaseUrl = TextUtils.isEmpty(baseUrl) ? defaultBaseUrl(providerId) : baseUrl.trim();
+            if (TextUtils.isEmpty(resolvedBaseUrl)) {
+                // 自定义 provider 无默认 base_url 且未显式提供时拒绝保存（同 setProvider）
+                Logger.logError(LOG_TAG, "Cannot save api key for " + providerId + ": base_url is empty");
+                return false;
+            }
             provider.put("base_url", resolvedBaseUrl);
             providers.put(providerId, provider);
             if (TextUtils.isEmpty(document.optString("active"))) document.put("active", providerId);

--- a/apps/coomi-app/app/src/main/java/app/coomi/CoomiService.java
+++ b/apps/coomi-app/app/src/main/java/app/coomi/CoomiService.java
@@ -116,8 +116,14 @@ public class CoomiService extends Service {
         super.onDestroy();
     }
 
+    /**
+     * bootstrap 是否已完整安装。只检查 bin/bash 不可靠：安装中断会留下残缺 prefix
+     * （bin/ 在、lib/ 缺）→ bash/dpkg 因缺 libandroid-support.so 等起不来
+     * （CANNOT LINK EXECUTABLE）。以核心 shell 与基础库同时存在为准。
+     */
     public static boolean isBootstrapInstalled() {
-        return new File(prefix() + "/bin/bash").isFile();
+        return new File(prefix() + "/bin/bash").isFile()
+            && new File(prefix() + "/lib/libandroid-support.so").isFile();
     }
 
     public static boolean isDeployComplete() {

--- a/apps/coomi-app/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/apps/coomi-app/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -109,11 +109,18 @@ public final class TermuxInstaller {
         if (FileUtils.directoryFileExists(TERMUX_PREFIX_DIR_PATH, true)) {
             if (TermuxFileUtils.isTermuxPrefixDirectoryEmpty()) {
                 Logger.logInfo(LOG_TAG, "The termux prefix directory \"" + TERMUX_PREFIX_DIR_PATH + "\" exists but is empty or only contains specific unimportant files.");
-            } else {
+            } else if (isBootstrapComplete()) {
                 // Upgrade path: refresh the Coomi install script and shell environment.
                 createCoomiScripts(activity);
                 whenDone.run();
                 return;
+            } else {
+                // Bootstrap 解压中断（如安装过程中进程被杀/被系统回收）会留下残缺的 prefix：
+                // bin/ 等靠前的条目已解压，lib/ 等靠后的缺失 → bash/dpkg 因缺
+                // libandroid-support.so、libmd.so 等起不来（CANNOT LINK EXECUTABLE）。
+                // 不能只凭 usr/ 非空就跳过安装，必须走下方完整重装（安装线程会先删除残缺 prefix）。
+                Logger.logWarn(LOG_TAG, "The termux prefix directory \"" + TERMUX_PREFIX_DIR_PATH +
+                    "\" exists but bootstrap is incomplete (missing usr/bin/bash or usr/lib/libandroid-support.so); re-installing bootstrap.");
             }
         } else if (FileUtils.fileExists(TERMUX_PREFIX_DIR_PATH, false)) {
             Logger.logInfo(LOG_TAG, "The termux prefix directory \"" + TERMUX_PREFIX_DIR_PATH + "\" does not exist but another file exists at its destination.");
@@ -388,6 +395,17 @@ public final class TermuxInstaller {
         return FileUtils.createDirectoryFile(directory.getAbsolutePath());
     }
 
+    /**
+     * 判断已存在的 termux prefix 是否为完整可用的 bootstrap。
+     * 只检查目录存在/非空不可靠：解压中断会留下残缺 prefix（bin/ 在、lib/ 缺），
+     * 导致 bash/dpkg 因缺 libandroid-support.so 等起不来。
+     * 以核心 shell 与基础库同时存在作为完整标记。
+     */
+    private static boolean isBootstrapComplete() {
+        return new File(TERMUX_PREFIX_DIR_PATH + "/bin/bash").exists()
+            && new File(TERMUX_PREFIX_DIR_PATH + "/lib/libandroid-support.so").exists();
+    }
+
     public static byte[] loadZipBytes() {
         // Only load the shared library when necessary to save memory usage.
         System.loadLibrary("termux-bootstrap");
@@ -419,9 +437,48 @@ public final class TermuxInstaller {
             //noinspection OctalInteger
             Os.chmod(envScript.getAbsolutePath(), 0644);
 
+            // bootstrap 由官方 Termux 构建，login 等 shell 脚本把包路径硬编码为
+            // "/data/data/com.termux/files"，在本包名（如 com.coomi.android）下
+            // interpreter 不存在 → exec $PREFIX/bin/login 报 ENOENT（"No such file"）。
+            // 解压后把文本脚本中的包路径替换为本包路径（ELF 二进制不在此替换）。
+            patchBootstrapPackagePaths();
+
             Logger.logInfo(LOG_TAG, "Created coomi-rs shell environment");
         } catch (Exception e) {
             Logger.logStackTraceWithMessage(LOG_TAG, "Failed to create Coomi scripts", e);
+        }
+    }
+
+    /** 把官方 bootstrap 脚本里硬编码的 com.termux 包路径替换为本包路径。 */
+    private static void patchBootstrapPackagePaths() {
+        String legacyDataPath = "/data/data/com.termux/files";
+        String targetDataPath = TermuxConstants.TERMUX_FILES_DIR_PATH;
+        File[] scripts = {
+            new File(TERMUX_PREFIX_DIR_PATH + "/bin/login"),
+            new File(TERMUX_PREFIX_DIR_PATH + "/bin/sh"),
+            new File(TERMUX_PREFIX_DIR_PATH + "/etc/profile"),
+            new File(TERMUX_PREFIX_DIR_PATH + "/etc/bash.bashrc"),
+        };
+        for (File script : scripts) {
+            try {
+                if (!script.isFile()) continue;
+                byte[] raw = java.nio.file.Files.readAllBytes(script.toPath());
+                // 只处理文本脚本（无 NUL 字节）；ELF 二进制长度不符，替换会破坏文件。
+                boolean hasNul = false;
+                for (byte b : raw) {
+                    if (b == 0) { hasNul = true; break; }
+                }
+                if (hasNul) continue;
+                String content = new String(raw, java.nio.charset.StandardCharsets.UTF_8);
+                String patched = content.replace(legacyDataPath, targetDataPath);
+                if (!patched.equals(content)) {
+                    java.nio.file.Files.write(
+                        script.toPath(), patched.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                    Logger.logInfo(LOG_TAG, "Patched package path in " + script.getAbsolutePath());
+                }
+            } catch (Exception e) {
+                Logger.logWarn(LOG_TAG, "Failed to patch " + script.getAbsolutePath() + ": " + e.getMessage());
+            }
         }
     }
 

--- a/apps/coomi-app/termux-shared/src/main/java/com/termux/shared/termux/shell/command/environment/TermuxShellEnvironment.java
+++ b/apps/coomi-app/termux-shared/src/main/java/com/termux/shared/termux/shell/command/environment/TermuxShellEnvironment.java
@@ -86,9 +86,12 @@ public class TermuxShellEnvironment extends AndroidShellEnvironment {
                 environment.put(ENV_PATH, TermuxConstants.TERMUX_BIN_PREFIX_DIR_PATH + ":" + TermuxConstants.TERMUX_BIN_PREFIX_DIR_PATH + "/applets");
                 environment.put(ENV_LD_LIBRARY_PATH, TermuxConstants.TERMUX_LIB_PREFIX_DIR_PATH);
             } else {
-                // Termux binaries on Android 7+ rely on DT_RUNPATH, so LD_LIBRARY_PATH should be unset by default
+                // Termux binaries on Android 7+ rely on DT_RUNPATH, so LD_LIBRARY_PATH should be unset by default.
+                // Coomi 例外：官方 bootstrap 的 ELF 把 DT_RUNPATH 硬编码为 /data/data/com.termux/files/usr/lib，
+                // 本包（com.coomi.android）下该路径不存在 → linker 找不到 libandroid-support.so 等
+                // （CANNOT LINK EXECUTABLE）。LD_LIBRARY_PATH 优先级高于 DT_RUNPATH，注入 $PREFIX/lib 覆盖。
                 environment.put(ENV_PATH, TermuxConstants.TERMUX_BIN_PREFIX_DIR_PATH);
-                environment.remove(ENV_LD_LIBRARY_PATH);
+                environment.put(ENV_LD_LIBRARY_PATH, TermuxConstants.TERMUX_LIB_PREFIX_DIR_PATH);
             }
         }
 

--- a/apps/coomi-rs/Cargo.lock
+++ b/apps/coomi-rs/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "chrono",
  "clap",
  "coomi-catalogs",
  "coomi-engine",

--- a/apps/coomi-rs/engine/src/session.rs
+++ b/apps/coomi-rs/engine/src/session.rs
@@ -322,15 +322,23 @@ fn derive_summary(messages: &[ChatMessage]) -> String {
     if full.chars().count() <= SUMMARY_MAX_CHARS || rounds.len() <= 2 {
         return full.chars().take(SUMMARY_MAX_CHARS).collect();
     }
-    // 超限：首末轮完整，中间轮只保留 user 问题；压缩后仍超限则整体截断。
+    // 超限：首末轮完整；中间轮只保留 user 问题（每轮最多 24 字符），
+    // 按预算从最早的中间轮开始装，**末轮永远完整**——保证最新意图的
+    // 尾部关键词不被硬截断（与「尾部关键词不漏检」的目标一致）。
     let first = rendered.first().cloned().unwrap_or_default();
     let last = rendered.last().cloned().unwrap_or_default();
-    let middle: Vec<String> = rounds[1..rounds.len() - 1]
-        .iter()
-        .map(|round| round.user.clone())
-        .collect();
-    let condensed = [first, middle.join("；"), last].join("；");
-    condensed.chars().take(SUMMARY_MAX_CHARS).collect()
+    let mut budget = SUMMARY_MAX_CHARS
+        .saturating_sub(first.chars().count() + last.chars().count());
+    let mut middle: Vec<String> = Vec::new();
+    for round in &rounds[1..rounds.len() - 1] {
+        let user: String = round.user.chars().take(24).collect();
+        let user_len = user.chars().count();
+        if !user.is_empty() && budget >= user_len {
+            budget -= user_len;
+            middle.push(user);
+        }
+    }
+    [first, middle.join("；"), last].join("；")
 }
 
 /// 摘要总长上限（字符）。
@@ -503,6 +511,32 @@ mod tests {
         assert!(summary.contains("第 11 轮"), "末轮应保留");
         // 中间轮退化为 user 问题仍可检索。
         assert!(summary.contains("第 5 轮"), "中间轮 user 问题应保留");
+    }
+
+    #[test]
+    fn derive_summary_keeps_last_round_tail_under_budget_pressure() {
+        // 20 轮 + 长回复：压缩预算吃紧时**末轮尾部关键词必须保留**（防硬截断漏检）。
+        const KEYWORD: &str = "末轮保留关键";
+        let mut messages = Vec::new();
+        for i in 0..20 {
+            messages.push(ChatMessage::user(format!("第 {i} 轮的问题")));
+            let reply = format!(
+                "第 {i} 轮回复：{}……最后结论关键字是{KEYWORD}",
+                "细节内容".repeat(30),
+            );
+            messages.push(ChatMessage::assistant(&reply, Vec::new()));
+        }
+        let summary = derive_summary(&messages);
+        assert!(
+            summary.chars().count() <= SUMMARY_MAX_CHARS,
+            "摘要超长: {} 字符",
+            summary.chars().count()
+        );
+        assert!(
+            summary.ends_with(&format!("{KEYWORD}")),
+            "末轮尾部关键词应保留（防硬截断），实际结尾: {:?}",
+            summary.chars().rev().take(12).collect::<String>()
+        );
     }
 
     #[test]

--- a/apps/coomi-rs/engine/src/session.rs
+++ b/apps/coomi-rs/engine/src/session.rs
@@ -250,49 +250,107 @@ fn derive_title(value: &str) -> String {
     }
 }
 
-/// 本地规则摘要：首条用户消息 + 末尾 assistant 回复（各截断），以 " → " 连接。
-/// 无 assistant 消息时退化为首条用户消息。
+/// 多轮采样摘要：遍历 (user, assistant) 轮次，每轮取 user 前 40 字符 +
+/// assistant 首尾各 48 字符，以 "；" 连接轮次。
+/// 总长超 `SUMMARY_MAX_CHARS` 时保留首末轮完整、中间轮退化为只留 user 问题，
+/// 保证多轮对话里中间轮次的核心主题（问题/结论）也能被检索命中。
 fn derive_summary(messages: &[ChatMessage]) -> String {
-    let first = first_user_content(messages)
-        .map(compact_preview)
-        .unwrap_or_default();
-    let last_assistant = messages
-        .iter()
-        .rev()
-        .find(|message| {
-            message.role == crate::Role::Assistant
-                && !message.content.trim().is_empty()
-                && !message.compaction_summary
-        })
-        .map(|message| summarize_assistant(&message.content))
-        .unwrap_or_default();
-    if first.is_empty() {
+    const ROUND_USER_CHARS: usize = 40;
+    const ROUND_ASSISTANT_CHARS: usize = 48;
+
+    struct Round {
+        user: String,
+        assistant: String,
+    }
+
+    let mut rounds: Vec<Round> = Vec::new();
+    let mut pending_user: Option<String> = None;
+    for message in messages {
+        if message.compaction_summary {
+            continue;
+        }
+        match message.role {
+            crate::Role::User if !message.internal => {
+                // 连续多条 user（旧会话/连续提问）：前一条作为“无回复”轮次保留，
+                // 避免被覆盖丢失。
+                if let Some(prev) = pending_user.take() {
+                    rounds.push(Round {
+                        user: prev,
+                        assistant: String::new(),
+                    });
+                }
+                pending_user = Some(
+                    compact_preview(&message.content)
+                        .chars()
+                        .take(ROUND_USER_CHARS)
+                        .collect(),
+                );
+            }
+            crate::Role::Assistant if !message.content.trim().is_empty() => {
+                if let Some(user) = pending_user.take() {
+                    rounds.push(Round {
+                        user,
+                        assistant: summarize_assistant(&message.content, ROUND_ASSISTANT_CHARS),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(user) = pending_user {
+        rounds.push(Round {
+            user,
+            assistant: String::new(),
+        });
+    }
+    rounds.retain(|round| !round.user.is_empty() || !round.assistant.is_empty());
+    if rounds.is_empty() {
         return String::new();
     }
-    if last_assistant.is_empty() {
-        first
-    } else {
-        format!("{first} → {last_assistant}")
+
+    let rendered: Vec<String> = rounds
+        .iter()
+        .map(|round| {
+            if round.assistant.is_empty() {
+                round.user.clone()
+            } else {
+                format!("{} → {}", round.user, round.assistant)
+            }
+        })
+        .collect();
+    let full = rendered.join("；");
+    if full.chars().count() <= SUMMARY_MAX_CHARS || rounds.len() <= 2 {
+        return full.chars().take(SUMMARY_MAX_CHARS).collect();
     }
+    // 超限：首末轮完整，中间轮只保留 user 问题；压缩后仍超限则整体截断。
+    let first = rendered.first().cloned().unwrap_or_default();
+    let last = rendered.last().cloned().unwrap_or_default();
+    let middle: Vec<String> = rounds[1..rounds.len() - 1]
+        .iter()
+        .map(|round| round.user.clone())
+        .collect();
+    let condensed = [first, middle.join("；"), last].join("；");
+    condensed.chars().take(SUMMARY_MAX_CHARS).collect()
 }
 
-/// 助手回复摘要：首尾双侧采样（各 `SUMMARY_TAIL_CHARS` 字符）。
+/// 摘要总长上限（字符）。
+const SUMMARY_MAX_CHARS: usize = 800;
+
+/// 助手回复摘要：首尾双侧采样（各 `head_tail` 字符）。
 /// 只取开头会把长回复中后段的关键信息（技术词、结论）漏掉，
 /// 导致检索命中不了——检索的价值正在于这些词。
-const SUMMARY_TAIL_CHARS: usize = 96;
-
-fn summarize_assistant(content: &str) -> String {
+fn summarize_assistant(content: &str, head_tail: usize) -> String {
     let single_line = content.split_whitespace().collect::<Vec<_>>().join(" ");
     let s = single_line.trim();
     let len = s.chars().count();
-    if len <= SUMMARY_TAIL_CHARS * 2 {
-        return s.chars().take(SUMMARY_TAIL_CHARS * 2).collect();
+    if len <= head_tail * 2 {
+        return s.chars().take(head_tail * 2).collect();
     }
-    let head: String = s.chars().take(SUMMARY_TAIL_CHARS).collect();
+    let head: String = s.chars().take(head_tail).collect();
     let tail: String = s
         .chars()
         .rev()
-        .take(SUMMARY_TAIL_CHARS)
+        .take(head_tail)
         .collect::<Vec<_>>()
         .into_iter()
         .rev()
@@ -368,10 +426,10 @@ mod tests {
         assert_eq!(listed[0].title.chars().count(), 43);
         assert!(listed[0].title.starts_with("first message"));
         assert!(listed[0].title.ends_with('…'));
-        // 摘要含首条 user 与末尾 assistant 回复。
+        // 多轮采样：首轮 user、末尾 assistant 回复、以及中间轮 user 问题都应进摘要。
         assert!(listed[0].summary.contains("first message"));
         assert!(listed[0].summary.contains("finished the migration"));
-        assert!(!listed[0].summary.contains("second user message"));
+        assert!(listed[0].summary.contains("second user message"));
     }
 
     #[test]
@@ -384,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn derive_summary_links_first_user_and_last_assistant() {
+    fn derive_summary_links_every_user_assistant_round() {
         let messages = vec![
             ChatMessage::user("fix the parser"),
             ChatMessage::assistant("on it", Vec::new()),
@@ -392,10 +450,59 @@ mod tests {
             ChatMessage::assistant("tests updated", Vec::new()),
         ];
         let summary = derive_summary(&messages);
-        assert_eq!(summary, "fix the parser → tests updated");
+        assert_eq!(
+            summary,
+            "fix the parser → on it；also update tests → tests updated"
+        );
         // 无 assistant 时退化为首条 user。
         let only_user = vec![ChatMessage::user("just a note")];
         assert_eq!(derive_summary(&only_user), "just a note");
+    }
+
+    #[test]
+    fn derive_summary_covers_middle_round_keywords() {
+        // 3 轮对话：中间轮次的 user 问题必须进摘要，否则检索命中不了。
+        let messages = vec![
+            ChatMessage::user("Redis 缓存穿透是什么"),
+            ChatMessage::assistant("穿透：查不存在的 key，方案是布隆过滤器", Vec::new()),
+            ChatMessage::user("那缓存雪崩呢"),
+            ChatMessage::assistant("雪崩：一批 key 同时过期，方案是 TTL 随机化", Vec::new()),
+            ChatMessage::user("击穿和穿透怎么区分"),
+            ChatMessage::assistant("击穿：热 key 失效瞬间并发打爆，方案是互斥锁", Vec::new()),
+        ];
+        let summary = derive_summary(&messages);
+        assert!(
+            summary.contains("缓存雪崩"),
+            "中间轮 user 问题应进摘要，实际: {summary:?}"
+        );
+        assert!(
+            summary.contains("击穿"),
+            "末轮 user 问题应进摘要，实际: {summary:?}"
+        );
+        assert!(summary.contains("布隆过滤器"), "首轮 assistant 结论应进摘要");
+    }
+
+    #[test]
+    fn derive_summary_compresses_many_rounds_to_budget() {
+        // 很多轮 + 长回复：总长不能爆掉 SUMMARY_MAX_CHARS，且首末轮保留。
+        let mut messages = Vec::new();
+        for i in 0..12 {
+            messages.push(ChatMessage::user(format!("第 {i} 轮的问题是什么")));
+            messages.push(ChatMessage::assistant(
+                &format!("这是第 {i} 轮的回复，内容比较长，包含一些技术细节和结论。"),
+                Vec::new(),
+            ));
+        }
+        let summary = derive_summary(&messages);
+        assert!(
+            summary.chars().count() <= SUMMARY_MAX_CHARS,
+            "摘要超长: {} 字符",
+            summary.chars().count()
+        );
+        assert!(summary.contains("第 0 轮"), "首轮应保留");
+        assert!(summary.contains("第 11 轮"), "末轮应保留");
+        // 中间轮退化为 user 问题仍可检索。
+        assert!(summary.contains("第 5 轮"), "中间轮 user 问题应保留");
     }
 
     #[test]

--- a/apps/coomi-rs/engine/src/session.rs
+++ b/apps/coomi-rs/engine/src/session.rs
@@ -264,7 +264,7 @@ fn derive_summary(messages: &[ChatMessage]) -> String {
                 && !message.content.trim().is_empty()
                 && !message.compaction_summary
         })
-        .map(|message| compact_preview(&message.content))
+        .map(|message| summarize_assistant(&message.content))
         .unwrap_or_default();
     if first.is_empty() {
         return String::new();
@@ -274,6 +274,30 @@ fn derive_summary(messages: &[ChatMessage]) -> String {
     } else {
         format!("{first} → {last_assistant}")
     }
+}
+
+/// 助手回复摘要：首尾双侧采样（各 `SUMMARY_TAIL_CHARS` 字符）。
+/// 只取开头会把长回复中后段的关键信息（技术词、结论）漏掉，
+/// 导致检索命中不了——检索的价值正在于这些词。
+const SUMMARY_TAIL_CHARS: usize = 96;
+
+fn summarize_assistant(content: &str) -> String {
+    let single_line = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    let s = single_line.trim();
+    let len = s.chars().count();
+    if len <= SUMMARY_TAIL_CHARS * 2 {
+        return s.chars().take(SUMMARY_TAIL_CHARS * 2).collect();
+    }
+    let head: String = s.chars().take(SUMMARY_TAIL_CHARS).collect();
+    let tail: String = s
+        .chars()
+        .rev()
+        .take(SUMMARY_TAIL_CHARS)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("{head}…{tail}")
 }
 
 #[cfg(test)]
@@ -372,5 +396,25 @@ mod tests {
         // 无 assistant 时退化为首条 user。
         let only_user = vec![ChatMessage::user("just a note")];
         assert_eq!(derive_summary(&only_user), "just a note");
+    }
+
+    #[test]
+    fn derive_summary_captures_tail_keywords_of_long_reply() {
+        // 长回复：关键信息（多进程）只出现在尾部，只取开头会漏掉。
+        let mut long = String::from("GIL 全称 Global Interpreter Lock，它让 CPython 同一时刻只有一个线程执行字节码。");
+        long.push_str(&"a".repeat(2000));
+        long.push_str("需要的话我可以帮你写一个对比 GIL 影响、或用多进程/NumPy 加速的具体示例。");
+        let messages = vec![
+            ChatMessage::user("Python 的 GIL 是什么？影响什么场景"),
+            ChatMessage::assistant(&long, Vec::new()),
+        ];
+        let summary = derive_summary(&messages);
+        assert!(summary.contains("多进程"), "摘要应包含尾部关键词，实际: {summary:?}");
+        // 短回复双侧不重复、不截断过多。
+        let short = vec![
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello world", Vec::new()),
+        ];
+        assert_eq!(derive_summary(&short), "hi → hello world");
     }
 }

--- a/apps/coomi-rs/engine/src/session.rs
+++ b/apps/coomi-rs/engine/src/session.rs
@@ -25,6 +25,12 @@ pub struct Session {
     pub updated_at: DateTime<Utc>,
     pub messages: Vec<ChatMessage>,
     pub usage: TokenUsage,
+    /// 会话标题：首条用户消息的本地推导，供会话列表/检索使用。
+    #[serde(default)]
+    pub title: String,
+    /// 会话一句话摘要：本地规则推导（首条 user + 末尾 assistant），供检索匹配。
+    #[serde(default)]
+    pub summary: String,
     #[serde(default)]
     pub context: ContextState,
     #[serde(default)]
@@ -47,6 +53,8 @@ impl Session {
             updated_at: now,
             messages: Vec::new(),
             usage: TokenUsage::default(),
+            title: String::new(),
+            summary: String::new(),
             context: ContextState::default(),
             plan: None,
             loop_state: None,
@@ -83,7 +91,12 @@ pub struct SessionSummary {
     pub model: String,
     pub cwd: PathBuf,
     pub updated_at: DateTime<Utc>,
+    /// 首条用户消息的短预览（向后兼容）。
     pub preview: String,
+    /// 会话标题：持久化的 Session.title，缺省时惰性推导。
+    pub title: String,
+    /// 会话摘要：持久化的 Session.summary，缺省时惰性推导。
+    pub summary: String,
 }
 
 pub struct SessionStore {
@@ -175,12 +188,22 @@ impl SessionStore {
             {
                 continue;
             }
-            let preview = session
-                .messages
-                .iter()
-                .find(|message| message.role == crate::Role::User)
-                .map(|message| compact_preview(&message.content))
+            let preview = first_user_content(&session.messages)
+                .map(compact_preview)
                 .unwrap_or_default();
+            // title/summary 为空的旧会话在这里惰性推导，无需迁移写盘。
+            let title = if session.title.trim().is_empty() {
+                first_user_content(&session.messages)
+                    .map(derive_title)
+                    .unwrap_or_default()
+            } else {
+                session.title.clone()
+            };
+            let summary = if session.summary.trim().is_empty() {
+                derive_summary(&session.messages)
+            } else {
+                session.summary.clone()
+            };
             summaries.push(SessionSummary {
                 id: session.id,
                 provider_id: session.provider_id,
@@ -188,6 +211,8 @@ impl SessionStore {
                 cwd: session.cwd,
                 updated_at: session.updated_at,
                 preview,
+                title,
+                summary,
             });
         }
         summaries.sort_by_key(|summary| Reverse(summary.updated_at));
@@ -204,6 +229,53 @@ fn compact_preview(value: &str) -> String {
     single_line.chars().take(72).collect()
 }
 
+/// 首条真实用户消息的原文（跳过 internal 消息，如自动注入的指令）。
+fn first_user_content(messages: &[ChatMessage]) -> Option<&str> {
+    messages
+        .iter()
+        .find(|message| message.role == crate::Role::User && !message.internal)
+        .map(|message| message.content.as_str())
+}
+
+/// 标题：首条用户消息压缩为一行，截断到 42 字符（与前端 deriveTitle 一致）。
+fn derive_title(value: &str) -> String {
+    let single_line = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let trimmed = single_line.trim();
+    let mut chars = trimmed.chars();
+    let head: String = chars.by_ref().take(42).collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
+/// 本地规则摘要：首条用户消息 + 末尾 assistant 回复（各截断），以 " → " 连接。
+/// 无 assistant 消息时退化为首条用户消息。
+fn derive_summary(messages: &[ChatMessage]) -> String {
+    let first = first_user_content(messages)
+        .map(compact_preview)
+        .unwrap_or_default();
+    let last_assistant = messages
+        .iter()
+        .rev()
+        .find(|message| {
+            message.role == crate::Role::Assistant
+                && !message.content.trim().is_empty()
+                && !message.compaction_summary
+        })
+        .map(|message| compact_preview(&message.content))
+        .unwrap_or_default();
+    if first.is_empty() {
+        return String::new();
+    }
+    if last_assistant.is_empty() {
+        first
+    } else {
+        format!("{first} → {last_assistant}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,13 +288,89 @@ mod tests {
         session
             .messages
             .push(ChatMessage::user("inspect this project"));
+        session
+            .messages
+            .push(ChatMessage::assistant("the build is green", Vec::new()));
         store.save(&session).expect("save session");
 
         let listed = store.list(Some(home.path())).expect("list sessions");
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].preview, "inspect this project");
+        assert_eq!(listed[0].title, "inspect this project");
+        assert_eq!(listed[0].summary, "inspect this project → the build is green");
         assert_eq!(store.load(session.id).expect("load session").model, "model");
         assert!(store.delete(session.id).expect("delete session"));
         assert!(!store.delete(session.id).expect("delete missing session"));
+    }
+
+    #[test]
+    fn list_lazily_derives_title_and_summary_for_old_sessions() {
+        let home = tempfile::tempdir().expect("temporary home");
+        let store = SessionStore::new(home.path());
+        // 模拟旧版本会话：无 title/summary 字段（serde default 兼容）。
+        let mut session = Session::new("provider", "model", home.path().to_path_buf());
+        session.title.clear();
+        session.summary.clear();
+        let long_first = format!("first message {}", "x".repeat(200));
+        session.messages.push(ChatMessage::user(long_first.clone()));
+        session
+            .messages
+            .push(ChatMessage::user("second user message, not the title"));
+        session
+            .messages
+            .push(ChatMessage::assistant("finished the migration", Vec::new()));
+        store.save(&session).expect("save session");
+
+        // 反序列化旧 JSON（无 title/summary 键）仍然成功。
+        let path = store.path(session.id);
+        let mut value = serde_json::to_value(&session).expect("serialize session");
+        value
+            .as_object_mut()
+            .expect("session object")
+            .remove("title");
+        value
+            .as_object_mut()
+            .expect("session object")
+            .remove("summary");
+        std::fs::write(&path, serde_json::to_vec_pretty(&value).expect("pretty json"))
+            .expect("write old-style json");
+        let loaded = store.load(session.id).expect("load old-style session");
+        assert!(loaded.title.is_empty());
+        assert!(loaded.summary.is_empty());
+
+        let listed = store.list(Some(home.path())).expect("list sessions");
+        assert_eq!(listed.len(), 1);
+        // 标题取首条 user 消息并截断到 42 字符 + 省略号。
+        assert_eq!(listed[0].title.chars().count(), 43);
+        assert!(listed[0].title.starts_with("first message"));
+        assert!(listed[0].title.ends_with('…'));
+        // 摘要含首条 user 与末尾 assistant 回复。
+        assert!(listed[0].summary.contains("first message"));
+        assert!(listed[0].summary.contains("finished the migration"));
+        assert!(!listed[0].summary.contains("second user message"));
+    }
+
+    #[test]
+    fn derive_title_compresses_and_truncates() {
+        assert_eq!(derive_title("  hello\n  world  "), "hello world");
+        let long = "a".repeat(100);
+        let title = derive_title(&long);
+        assert_eq!(title.chars().count(), 43);
+        assert!(title.ends_with('…'));
+    }
+
+    #[test]
+    fn derive_summary_links_first_user_and_last_assistant() {
+        let messages = vec![
+            ChatMessage::user("fix the parser"),
+            ChatMessage::assistant("on it", Vec::new()),
+            ChatMessage::user("also update tests"),
+            ChatMessage::assistant("tests updated", Vec::new()),
+        ];
+        let summary = derive_summary(&messages);
+        assert_eq!(summary, "fix the parser → tests updated");
+        // 无 assistant 时退化为首条 user。
+        let only_user = vec![ChatMessage::user("just a note")];
+        assert_eq!(derive_summary(&only_user), "just a note");
     }
 }

--- a/apps/coomi-rs/ui/Cargo.toml
+++ b/apps/coomi-rs/ui/Cargo.toml
@@ -37,4 +37,5 @@ unicode-width.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+chrono.workspace = true
 tempfile.workspace = true

--- a/apps/coomi-rs/ui/src/main.rs
+++ b/apps/coomi-rs/ui/src/main.rs
@@ -453,7 +453,7 @@ fn print_sessions(store: &SessionStore, cwd: Option<&Path>) -> Result<()> {
             session.updated_at.format("%Y-%m-%d %H:%M"),
             session.provider_id,
             session.model,
-            session.preview
+            if session.title.is_empty() { &session.preview } else { &session.title }
         );
     }
     Ok(())

--- a/apps/coomi-rs/ui/src/terminal_ui/mod.rs
+++ b/apps/coomi-rs/ui/src/terminal_ui/mod.rs
@@ -3379,7 +3379,8 @@ fn model_matches(choice: &ModelChoice, query: &str) -> bool {
 
 /// 会话检索打分：查询拆词后按 title(×5)/summary(×3)/preview(×1)/model/id 加权求和。
 /// 分词与前端 sessions.ts 保持一致（Unicode 字母数字 + `_`/`-`/`+`/`.`/`#`，词长 ≥2）；
-/// 精确匹配不中时用“紧凑版”（去空白）兜底，弥补「B+ 树」与「B+树」这类空白差异。
+/// 命中次数加权：同一词出现多次分数更高；紧凑版（去空白）仅在精确未命中时兜底，
+/// 弥补「B+ 树」与「B+树」这类空白差异。
 fn session_search_score(session: &SessionSummary, query: &str) -> usize {
     let terms = query
         .split(|character: char| {
@@ -3405,16 +3406,16 @@ fn session_search_score(session: &SessionSummary, query: &str) -> usize {
     let compact_summary = summary.replace(char::is_whitespace, "");
     let compact_preview = preview.replace(char::is_whitespace, "");
     terms.iter().fold(0usize, |score, term| {
-        let title_exact = title.contains(term.as_str());
-        let summary_exact = summary.contains(term.as_str());
-        let preview_exact = preview.contains(term.as_str());
+        let title_hits = title.matches(term.as_str()).count();
+        let summary_hits = summary.matches(term.as_str()).count();
+        let preview_hits = preview.matches(term.as_str()).count();
         score
-            + usize::from(title_exact) * 5
-            + usize::from(!title_exact && compact_title.contains(term.as_str())) * 2
-            + usize::from(summary_exact) * 3
-            + usize::from(!summary_exact && compact_summary.contains(term.as_str()))
-            + usize::from(preview_exact)
-            + usize::from(!preview_exact && compact_preview.contains(term.as_str()))
+            + title_hits * 5
+            + usize::from(title_hits == 0) * compact_title.matches(term.as_str()).count() * 2
+            + summary_hits * 3
+            + usize::from(summary_hits == 0) * compact_summary.matches(term.as_str()).count()
+            + preview_hits
+            + usize::from(preview_hits == 0) * compact_preview.matches(term.as_str()).count()
             + usize::from(model.contains(term.as_str()))
             + usize::from(id.contains(term.as_str()))
     })
@@ -3445,6 +3446,43 @@ fn catalog_matches(id: &str, name: &str, query: &str) -> bool {
 mod tests {
     use super::*;
     use std::fs;
+
+    /// 与前端 apps/web/src/stores/sessions.ts scoreSession 的对拍测试。
+    /// 语料在 tests/session_search_cases.json（两端共用），前端侧用
+    /// tests/check_session_search.mjs 跑同一份语料。改打分逻辑必须同步两端 + 语料。
+    #[test]
+    fn session_search_score_matches_shared_corpus() {
+        let corpus: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tests/session_search_cases.json"
+        ))
+        .expect("parse shared corpus");
+        let cases = corpus["cases"].as_array().expect("cases array");
+        let mut checked = 0;
+        for case in cases {
+            let query = case["query"].as_str().expect("query");
+            for (i, session) in case["sessions"].as_array().expect("sessions").iter().enumerate() {
+                let summary = SessionSummary {
+                    id: uuid::Uuid::nil(),
+                    provider_id: "demo".to_string(),
+                    model: session["model"].as_str().expect("model").to_string(),
+                    cwd: std::path::PathBuf::from("/tmp/demo"),
+                    updated_at: chrono::Utc::now(),
+                    preview: session["preview"].as_str().expect("preview").to_string(),
+                    title: session["title"].as_str().expect("title").to_string(),
+                    summary: session["summary"].as_str().expect("summary").to_string(),
+                };
+                let got = session_search_score(&summary, query);
+                let expect = session["expect"].as_u64().expect("expect") as usize;
+                checked += 1;
+                assert_eq!(
+                    got, expect,
+                    "query={query:?} case#{i} title={:?}",
+                    summary.title
+                );
+            }
+        }
+        assert!(checked >= 6, "语料用例数异常: {checked}");
+    }
 
     fn test_state() -> (tempfile::TempDir, TuiState) {
         let home = tempfile::tempdir().expect("temporary home");

--- a/apps/coomi-rs/ui/src/terminal_ui/mod.rs
+++ b/apps/coomi-rs/ui/src/terminal_ui/mod.rs
@@ -3417,7 +3417,8 @@ fn session_search_score(session: &SessionSummary, query: &str) -> usize {
             + preview_hits
             + usize::from(preview_hits == 0) * compact_preview.matches(term.as_str()).count()
             + usize::from(model.contains(term.as_str()))
-            + usize::from(id.contains(term.as_str()))
+            // uuid 片段匹配要求 ≥6 字符，避免「ab」这类 2 字符词随机命中 uuid 造成误报。
+            + usize::from(term.chars().count() >= 6 && id.contains(term.as_str()))
     })
 }
 

--- a/apps/coomi-rs/ui/src/terminal_ui/mod.rs
+++ b/apps/coomi-rs/ui/src/terminal_ui/mod.rs
@@ -3378,9 +3378,18 @@ fn model_matches(choice: &ModelChoice, query: &str) -> bool {
 }
 
 /// 会话检索打分：查询拆词后按 title(×5)/summary(×3)/preview(×1)/model/id 加权求和。
+/// 分词与前端 sessions.ts 保持一致（Unicode 字母数字 + `_`/`-`/`+`/`.`/`#`，词长 ≥2）；
+/// 精确匹配不中时用“紧凑版”（去空白）兜底，弥补「B+ 树」与「B+树」这类空白差异。
 fn session_search_score(session: &SessionSummary, query: &str) -> usize {
     let terms = query
-        .split(|character: char| !character.is_alphanumeric() && character != '_' && character != '-')
+        .split(|character: char| {
+            !character.is_alphanumeric()
+                && character != '_'
+                && character != '-'
+                && character != '+'
+                && character != '.'
+                && character != '#'
+        })
         .filter(|term| term.chars().count() >= 2)
         .map(str::to_lowercase)
         .collect::<Vec<_>>();
@@ -3392,11 +3401,20 @@ fn session_search_score(session: &SessionSummary, query: &str) -> usize {
     let preview = session.preview.to_lowercase();
     let model = session.model.to_lowercase();
     let id = session.id.to_string();
+    let compact_title = title.replace(char::is_whitespace, "");
+    let compact_summary = summary.replace(char::is_whitespace, "");
+    let compact_preview = preview.replace(char::is_whitespace, "");
     terms.iter().fold(0usize, |score, term| {
+        let title_exact = title.contains(term.as_str());
+        let summary_exact = summary.contains(term.as_str());
+        let preview_exact = preview.contains(term.as_str());
         score
-            + usize::from(title.contains(term.as_str())) * 5
-            + usize::from(summary.contains(term.as_str())) * 3
-            + usize::from(preview.contains(term.as_str()))
+            + usize::from(title_exact) * 5
+            + usize::from(!title_exact && compact_title.contains(term.as_str())) * 2
+            + usize::from(summary_exact) * 3
+            + usize::from(!summary_exact && compact_summary.contains(term.as_str()))
+            + usize::from(preview_exact)
+            + usize::from(!preview_exact && compact_preview.contains(term.as_str()))
             + usize::from(model.contains(term.as_str()))
             + usize::from(id.contains(term.as_str()))
     })

--- a/apps/coomi-rs/ui/src/terminal_ui/mod.rs
+++ b/apps/coomi-rs/ui/src/terminal_ui/mod.rs
@@ -2294,11 +2294,7 @@ fn overlay_item_count(app: &TuiState) -> usize {
             .iter()
             .filter(|item| model_matches(item, &query))
             .count(),
-        OverlayKind::History => app
-            .sessions
-            .iter()
-            .filter(|item| session_matches(item, &query))
-            .count(),
+        OverlayKind::History => ranked_sessions(&app.sessions, &query).len(),
         OverlayKind::Catalog => match overlay.catalog_tab {
             CatalogTab::Mcp => app
                 .mcp_entries
@@ -2357,10 +2353,8 @@ fn activate_overlay_selection(
             if !require_idle(app, "resume another session") {
                 return Ok(());
             }
-            if let Some(summary) = app
-                .sessions
-                .iter()
-                .filter(|item| session_matches(item, &query))
+            if let Some(summary) = ranked_sessions(&app.sessions, &query)
+                .into_iter()
                 .nth(selected)
                 .cloned()
             {
@@ -2518,12 +2512,7 @@ fn mark_selected_session_for_delete(app: &mut TuiState) {
         return;
     };
     let query = overlay.query.text().to_ascii_lowercase();
-    if let Some(summary) = app
-        .sessions
-        .iter()
-        .filter(|item| session_matches(item, &query))
-        .nth(overlay.selected)
-    {
+    if let Some(summary) = ranked_sessions(&app.sessions, &query).into_iter().nth(overlay.selected) {
         app.confirm_delete = Some(DeleteTarget::Session(summary.id));
     }
 }
@@ -3388,11 +3377,44 @@ fn model_matches(choice: &ModelChoice, query: &str) -> bool {
         || choice.provider_display.to_ascii_lowercase().contains(query)
 }
 
-fn session_matches(session: &SessionSummary, query: &str) -> bool {
-    query.is_empty()
-        || session.preview.to_ascii_lowercase().contains(query)
-        || session.model.to_ascii_lowercase().contains(query)
-        || session.id.to_string().contains(query)
+/// 会话检索打分：查询拆词后按 title(×5)/summary(×3)/preview(×1)/model/id 加权求和。
+fn session_search_score(session: &SessionSummary, query: &str) -> usize {
+    let terms = query
+        .split(|character: char| !character.is_alphanumeric() && character != '_' && character != '-')
+        .filter(|term| term.chars().count() >= 2)
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>();
+    if terms.is_empty() {
+        return 0;
+    }
+    let title = session.title.to_lowercase();
+    let summary = session.summary.to_lowercase();
+    let preview = session.preview.to_lowercase();
+    let model = session.model.to_lowercase();
+    let id = session.id.to_string();
+    terms.iter().fold(0usize, |score, term| {
+        score
+            + usize::from(title.contains(term.as_str())) * 5
+            + usize::from(summary.contains(term.as_str())) * 3
+            + usize::from(preview.contains(term.as_str()))
+            + usize::from(model.contains(term.as_str()))
+            + usize::from(id.contains(term.as_str()))
+    })
+}
+
+/// 按查询词对会话打分排序；空查询保持原序（updated_at 降序）。
+/// 渲染与选中/删除共用此函数，保证列表顺序与 nth(selected) 一致。
+fn ranked_sessions<'a>(sessions: &'a [SessionSummary], query: &str) -> Vec<&'a SessionSummary> {
+    if query.trim().is_empty() {
+        return sessions.iter().collect();
+    }
+    let mut scored = sessions
+        .iter()
+        .map(|session| (session, session_search_score(session, query)))
+        .collect::<Vec<_>>();
+    scored.retain(|(_, score)| *score > 0);
+    scored.sort_by_key(|(_, score)| std::cmp::Reverse(*score));
+    scored.into_iter().map(|(session, _)| session).collect()
 }
 
 fn catalog_matches(id: &str, name: &str, query: &str) -> bool {

--- a/apps/coomi-rs/ui/src/terminal_ui/render.rs
+++ b/apps/coomi-rs/ui/src/terminal_ui/render.rs
@@ -8,7 +8,7 @@ use super::ToolState;
 use super::TuiState;
 use super::catalog_matches;
 use super::model_matches;
-use super::session_matches;
+use super::ranked_sessions;
 use super::theme;
 use pulldown_cmark::Alignment as MarkdownAlignment;
 use pulldown_cmark::CodeBlockKind;
@@ -275,7 +275,10 @@ fn render_recent_sessions(frame: &mut Frame<'_>, area: Rect, app: &TuiState, div
                 Span::styled("● ", Style::default().fg(theme::MINT)),
                 Span::styled(format!("{date}  "), Style::default().fg(theme::MUTED)),
                 Span::styled(
-                    truncate_cells(&session.preview, preview_width),
+                    truncate_cells(
+                        if session.title.is_empty() { &session.preview } else { &session.title },
+                        preview_width,
+                    ),
                     Style::default().fg(theme::TEXT),
                 ),
             ]));
@@ -649,10 +652,8 @@ fn render_history(frame: &mut Frame<'_>, area: Rect, app: &TuiState) {
     let popup = popup_rect(area, 82, 23);
     let overlay = app.overlay.as_ref().expect("history overlay");
     let query = overlay.query.text();
-    let items = app
-        .sessions
-        .iter()
-        .filter(|session| session_matches(session, &query.to_ascii_lowercase()))
+    let items = ranked_sessions(&app.sessions, &query.to_ascii_lowercase())
+        .into_iter()
         .map(|session| {
             let active = session.id == app.session.id;
             ListItem::new(Line::from(vec![
@@ -669,7 +670,10 @@ fn render_history(frame: &mut Frame<'_>, area: Rect, app: &TuiState) {
                     Style::default().fg(theme::SKY),
                 ),
                 Span::styled(
-                    truncate_cells(&session.preview, 38),
+                    truncate_cells(
+                        if session.title.is_empty() { &session.preview } else { &session.title },
+                        38,
+                    ),
                     Style::default().fg(theme::TEXT),
                 ),
             ]))

--- a/apps/coomi-rs/ui/src/web.rs
+++ b/apps/coomi-rs/ui/src/web.rs
@@ -634,6 +634,8 @@ async fn list_sessions(State(state): State<AppState>) -> Json<Value> {
             "cwd": summary.cwd.display().to_string(),
             "updated_at": summary.updated_at,
             "preview": summary.preview,
+            "title": summary.title,
+            "summary": summary.summary,
             "created_at": full.as_ref().map(|s| s.created_at).unwrap_or(summary.updated_at),
             "usage": full.as_ref().map(|s| json!({
                 "input_tokens": s.usage.input_tokens,
@@ -2712,6 +2714,8 @@ mod tests {
         let mut found_idle = false;
         for session in sessions {
             let id = session["id"].as_str().expect("session id");
+            assert!(session["title"].is_string(), "session should expose title");
+            assert!(session["summary"].is_string(), "session should expose summary");
             if id == running_session.id.to_string() {
                 assert_eq!(session["running"], json!(true), "running session should report running");
                 found_running = true;

--- a/apps/coomi-rs/ui/tests/check_session_search.mjs
+++ b/apps/coomi-rs/ui/tests/check_session_search.mjs
@@ -36,7 +36,8 @@ function scoreSession(m, terms) {
     if (ph > 0) s += ph
     else s += count(compactPreview, t)
     if (model.includes(t)) s += 1
-    if (id.includes(t)) s += 1
+    // uuid 片段匹配要求 ≥6 字符，避免「ab」这类 2 字符词随机命中 uuid 造成误报。
+    if (t.length >= 6 && id.includes(t)) s += 1
     return acc + s
   }, 0)
 }

--- a/apps/coomi-rs/ui/tests/check_session_search.mjs
+++ b/apps/coomi-rs/ui/tests/check_session_search.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * 会话检索打分对拍脚本（前端侧）。
+ * 与 apps/web/src/stores/sessions.ts 的 scoreSession 保持逐行一致（含 id 匹配）；
+ * 与 apps/coomi-rs/ui/src/terminal_ui/mod.rs 的 session_search_score 共用
+ * 同目录 session_search_cases.json 语料。任一侧改动打分逻辑必须同步此处并重跑：
+ *   node apps/coomi-rs/ui/tests/check_session_search.mjs
+ */
+import { readFileSync } from 'node:fs'
+
+const corpus = JSON.parse(
+  readFileSync(new URL('./session_search_cases.json', import.meta.url), 'utf8'),
+)
+
+/** 与 web/src/stores/sessions.ts scoreSession 一致（改动需同步）。 */
+function scoreSession(m, terms) {
+  const hay = (s) => (s ?? '').toLowerCase()
+  const title = hay(m.title)
+  const summary = hay(m.summary)
+  const preview = hay(m.preview)
+  const model = hay(m.model)
+  const id = hay(m.id)
+  const compactTitle = title.replace(/\s+/g, '')
+  const compactSummary = summary.replace(/\s+/g, '')
+  const compactPreview = preview.replace(/\s+/g, '')
+  const count = (s, t) => s.split(t).length - 1
+  return terms.reduce((acc, t) => {
+    let s = 0
+    const th = count(title, t)
+    const sh = count(summary, t)
+    const ph = count(preview, t)
+    if (th > 0) s += th * 5
+    else s += count(compactTitle, t) * 2
+    if (sh > 0) s += sh * 3
+    else s += count(compactSummary, t)
+    if (ph > 0) s += ph
+    else s += count(compactPreview, t)
+    if (model.includes(t)) s += 1
+    if (id.includes(t)) s += 1
+    return acc + s
+  }, 0)
+}
+
+/** 与 web/src/stores/sessions.ts filtered 的分词一致。 */
+function termsOf(query) {
+  return query.trim().toLowerCase().match(/[\p{L}\p{N}_+.#-]{2,}/gu) ?? []
+}
+
+let failures = 0
+let total = 0
+for (const { query, sessions } of corpus.cases) {
+  const terms = termsOf(query)
+  for (const [i, session] of sessions.entries()) {
+    total += 1
+    const got = scoreSession(session, terms)
+    if (got !== session.expect) {
+      failures += 1
+      console.error(
+        `FAIL query=${JSON.stringify(query)} #${i} title=${JSON.stringify(session.title)} ` +
+          `expect=${session.expect} got=${got}`,
+      )
+    }
+  }
+}
+if (failures === 0) {
+  console.log(`OK  ${total} 个对拍断言全部通过（query 分词 + scoreSession 打分）`)
+} else {
+  console.error(`FAIL ${failures}/${total} 个断言失败`)
+  process.exit(1)
+}

--- a/apps/coomi-rs/ui/tests/session_search_cases.json
+++ b/apps/coomi-rs/ui/tests/session_search_cases.json
@@ -1,0 +1,83 @@
+{
+  "_comment": "会话检索打分对拍语料：Rust session_search_score（ui/src/terminal_ui/mod.rs）与前端 scoreSession（web/src/stores/sessions.ts）共用。两端修改打分逻辑时必须同步更新本文件的 expect 值并各自重跑测试。字段与 SessionSummary / SessionMeta 对应；id 固定为 nil uuid，不含任何查询词。",
+  "cases": [
+    {
+      "query": "多进程",
+      "sessions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "title": "Python 的 GIL 是什么？影响什么场景",
+          "summary": "多进程不受影响，多进程方案并行",
+          "preview": "多进程",
+          "model": "deepseek-chat",
+          "expect": 7
+        }
+      ]
+    },
+    {
+      "query": "docker",
+      "sessions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "title": "用两句话解释 Docker 容器和虚拟机的区别",
+          "summary": "Docker 容器与虚拟机对比",
+          "preview": "用两句话解释 Docker 容器",
+          "model": "deepseek-chat",
+          "expect": 9
+        }
+      ]
+    },
+    {
+      "query": "B+树",
+      "sessions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "title": "76408",
+          "summary": "B+ 树适合范围查询（原文带空格）",
+          "preview": "",
+          "model": "deepseek-chat",
+          "expect": 1
+        }
+      ]
+    },
+    {
+      "query": "量子纠缠",
+      "sessions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "title": "随便聊聊",
+          "summary": "今天天气不错",
+          "preview": "随便聊聊",
+          "model": "deepseek-chat",
+          "expect": 0
+        }
+      ]
+    },
+    {
+      "query": "Python GIL",
+      "sessions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "title": "Python 的 GIL 是什么？影响什么场景",
+          "summary": "GIL 全称 Global Interpreter Lock，影响多线程",
+          "preview": "Python 的 GIL",
+          "model": "deepseek-chat",
+          "expect": 15
+        }
+      ]
+    },
+    {
+      "query": "deepseek",
+      "sessions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "title": "测试",
+          "summary": "",
+          "preview": "",
+          "model": "deepseek-chat",
+          "expect": 1
+        }
+      ]
+    }
+  ]
+}

--- a/apps/coomi-rs/ui/tests/session_search_cases.json
+++ b/apps/coomi-rs/ui/tests/session_search_cases.json
@@ -78,6 +78,34 @@
           "expect": 1
         }
       ]
+    },
+    {
+      "_comment": "2 字符词不得命中 uuid（防误报）",
+      "query": "ab",
+      "sessions": [
+        {
+          "id": "ab000000-0000-0000-0000-000000000000",
+          "title": "测试标题",
+          "summary": "",
+          "preview": "",
+          "model": "deepseek-chat",
+          "expect": 0
+        }
+      ]
+    },
+    {
+      "_comment": "≥6 字符 uuid 片段允许命中（粘 ID 片段可搜）",
+      "query": "00000000",
+      "sessions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "title": "测试标题",
+          "summary": "",
+          "preview": "",
+          "model": "deepseek-chat",
+          "expect": 1
+        }
+      ]
     }
   ]
 }

--- a/apps/web/src/stores/sessions.ts
+++ b/apps/web/src/stores/sessions.ts
@@ -125,9 +125,9 @@ export const useSessionsStore = defineStore('sessions', () => {
     const q = query.value.trim().toLowerCase()
     if (!q) return sorted.value
     // 与 Rust 侧 ranked_sessions 一致：title×5 / summary×3 / preview×1 / model×1 加权打分排序。
-    // 注意：必须 Unicode 感知分词（\p{L}\p{N} 含中文），与 Rust 的 char::is_alphanumeric 对齐；
-    // 不能用 ASCII 正则 [a-z0-9]，否则中文查询词会被整体拆掉导致搜不到。
-    const terms = q.match(/[\p{L}\p{N}_-]{2,}/gu) ?? []
+    // 注意：必须 Unicode 感知分词（\p{L}\p{N} 含中文 + 技术符号 +.#），与 Rust 的
+    // is_alphanumeric 谓词对齐；不能用 ASCII 正则 [a-z0-9]，否则中文查询词会被整体拆掉。
+    const terms = q.match(/[\p{L}\p{N}_+.#-]{2,}/gu) ?? []
     if (terms.length === 0) return sorted.value
     return sorted.value
       .map(m => ({ m, score: scoreSession(m, terms) }))
@@ -196,11 +196,18 @@ export const useSessionsStore = defineStore('sessions', () => {
     const summary = hay(m.summary)
     const preview = hay(m.preview)
     const model = hay(m.model)
+    // 紧凑版（去空白）兜底：弥补「B+ 树」与「B+树」这类空白差异，权重减半。
+    const compactTitle = title.replace(/\s+/g, '')
+    const compactSummary = summary.replace(/\s+/g, '')
+    const compactPreview = preview.replace(/\s+/g, '')
     return terms.reduce((acc, t) => {
       let s = 0
       if (title.includes(t)) s += 5
+      else if (compactTitle.includes(t)) s += 2
       if (summary.includes(t)) s += 3
+      else if (compactSummary.includes(t)) s += 1
       if (preview.includes(t)) s += 1
+      else if (compactPreview.includes(t)) s += 1
       if (model.includes(t)) s += 1
       return acc + s
     }, 0)

--- a/apps/web/src/stores/sessions.ts
+++ b/apps/web/src/stores/sessions.ts
@@ -189,26 +189,33 @@ export const useSessionsStore = defineStore('sessions', () => {
     return t.length > 42 ? t.slice(0, 42) + '…' : t || '新对话'
   }
 
-  /** 会话检索打分：拆词后按 title/summary/preview/model 加权求和（与 Rust 侧一致）。 */
+  /** 会话检索打分：拆词后按 title/summary/preview/model 加权求和（与 Rust 侧一致）。
+   *  命中次数加权：同一词出现多次分数更高；紧凑版仅在精确未命中时兜底（权重减半）。 */
   function scoreSession(m: SessionMeta, terms: string[]): number {
     const hay = (s?: string) => (s ?? '').toLowerCase()
     const title = hay(m.title)
     const summary = hay(m.summary)
     const preview = hay(m.preview)
     const model = hay(m.model)
+    const id = hay(m.id)
     // 紧凑版（去空白）兜底：弥补「B+ 树」与「B+树」这类空白差异，权重减半。
     const compactTitle = title.replace(/\s+/g, '')
     const compactSummary = summary.replace(/\s+/g, '')
     const compactPreview = preview.replace(/\s+/g, '')
+    const count = (s: string, t: string) => s.split(t).length - 1
     return terms.reduce((acc, t) => {
       let s = 0
-      if (title.includes(t)) s += 5
-      else if (compactTitle.includes(t)) s += 2
-      if (summary.includes(t)) s += 3
-      else if (compactSummary.includes(t)) s += 1
-      if (preview.includes(t)) s += 1
-      else if (compactPreview.includes(t)) s += 1
+      const th = count(title, t)
+      const sh = count(summary, t)
+      const ph = count(preview, t)
+      if (th > 0) s += th * 5
+      else s += count(compactTitle, t) * 2
+      if (sh > 0) s += sh * 3
+      else s += count(compactSummary, t)
+      if (ph > 0) s += ph
+      else s += count(compactPreview, t)
       if (model.includes(t)) s += 1
+      if (id.includes(t)) s += 1
       return acc + s
     }, 0)
   }

--- a/apps/web/src/stores/sessions.ts
+++ b/apps/web/src/stores/sessions.ts
@@ -30,6 +30,14 @@ export interface SessionMeta {
   pinned: boolean
   /** 创建该会话时的工作目录；用于把不同项目的会话隔离开。 */
   cwd?: string
+  /** 引擎侧一句话摘要（/api/sessions 的 summary），用于检索与展示。 */
+  summary?: string
+  /** 引擎侧首条消息预览。 */
+  preview?: string
+  /** 引擎侧模型名。 */
+  model?: string
+  /** 用户手动重命名过：true 时引擎推导的标题不再覆盖。 */
+  renamed?: boolean
 }
 
 export interface SessionGroup {
@@ -116,7 +124,14 @@ export const useSessionsStore = defineStore('sessions', () => {
   const filtered = computed(() => {
     const q = query.value.trim().toLowerCase()
     if (!q) return sorted.value
-    return sorted.value.filter(m => m.title.toLowerCase().includes(q))
+    // 与 Rust 侧 ranked_sessions 一致：title×5 / summary×3 / preview×1 / model×1 加权打分排序。
+    const terms = q.split(/[^a-z0-9_\-]+/).filter(t => t.length >= 2)
+    if (terms.length === 0) return sorted.value
+    return sorted.value
+      .map(m => ({ m, score: scoreSession(m, terms) }))
+      .filter(x => x.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map(x => x.m)
   })
 
   /** 置顶 / 今天 / 昨天 / 7 天内 / 更早 / 其它目录 —— 空组不出现。 */
@@ -172,6 +187,23 @@ export const useSessionsStore = defineStore('sessions', () => {
     return t.length > 42 ? t.slice(0, 42) + '…' : t || '新对话'
   }
 
+  /** 会话检索打分：拆词后按 title/summary/preview/model 加权求和（与 Rust 侧一致）。 */
+  function scoreSession(m: SessionMeta, terms: string[]): number {
+    const hay = (s?: string) => (s ?? '').toLowerCase()
+    const title = hay(m.title)
+    const summary = hay(m.summary)
+    const preview = hay(m.preview)
+    const model = hay(m.model)
+    return terms.reduce((acc, t) => {
+      let s = 0
+      if (title.includes(t)) s += 5
+      if (summary.includes(t)) s += 3
+      if (preview.includes(t)) s += 1
+      if (model.includes(t)) s += 1
+      return acc + s
+    }, 0)
+  }
+
   function ensure(id: string, title = '新对话'): SessionMeta {
     let m = find(id)
     if (!m) {
@@ -198,6 +230,7 @@ export const useSessionsStore = defineStore('sessions', () => {
     const m = find(id)
     if (!m) return
     m.title = title.trim() || m.title
+    m.renamed = true
     persist()
   }
 
@@ -308,6 +341,8 @@ export const useSessionsStore = defineStore('sessions', () => {
         cwd: string
         updated_at: string
         preview: string
+        title: string
+        summary: string
         created_at: string
       }>
       const localById = new Map(metas.value.map(m => [m.id, m]))
@@ -317,12 +352,17 @@ export const useSessionsStore = defineStore('sessions', () => {
         const createdAt = local?.createdAt ?? (Date.parse(r.created_at) || updatedAt)
         return {
           id: r.id,
-          title: local?.title ?? (r.preview ? deriveTitle(r.preview) : '新对话'),
+          // 用户重命名过（renamed）则保留用户标题；否则引擎 title 优先，本地推导兜底。
+          title: local?.renamed ? local.title : (r.title || local?.title || (r.preview ? deriveTitle(r.preview) : '新对话')),
           createdAt,
           updatedAt,
           turns: local?.turns ?? 0,
           pinned: local?.pinned ?? false,
           cwd: r.cwd || local?.cwd,
+          summary: r.summary || local?.summary,
+          preview: r.preview || local?.preview,
+          model: r.model || local?.model,
+          renamed: local?.renamed,
         }
       })
       // 本地有而引擎暂无的（旧迁移 ID 等）保留，避免吞掉用户数据

--- a/apps/web/src/stores/sessions.ts
+++ b/apps/web/src/stores/sessions.ts
@@ -125,7 +125,9 @@ export const useSessionsStore = defineStore('sessions', () => {
     const q = query.value.trim().toLowerCase()
     if (!q) return sorted.value
     // 与 Rust 侧 ranked_sessions 一致：title×5 / summary×3 / preview×1 / model×1 加权打分排序。
-    const terms = q.split(/[^a-z0-9_\-]+/).filter(t => t.length >= 2)
+    // 注意：必须 Unicode 感知分词（\p{L}\p{N} 含中文），与 Rust 的 char::is_alphanumeric 对齐；
+    // 不能用 ASCII 正则 [a-z0-9]，否则中文查询词会被整体拆掉导致搜不到。
+    const terms = q.match(/[\p{L}\p{N}_-]{2,}/gu) ?? []
     if (terms.length === 0) return sorted.value
     return sorted.value
       .map(m => ({ m, score: scoreSession(m, terms) }))

--- a/apps/web/src/stores/sessions.ts
+++ b/apps/web/src/stores/sessions.ts
@@ -215,7 +215,8 @@ export const useSessionsStore = defineStore('sessions', () => {
       if (ph > 0) s += ph
       else s += count(compactPreview, t)
       if (model.includes(t)) s += 1
-      if (id.includes(t)) s += 1
+      // uuid 片段匹配要求 ≥6 字符，避免「ab」这类 2 字符词随机命中 uuid 造成误报。
+      if (t.length >= 6 && id.includes(t)) s += 1
       return acc + s
     }, 0)
   }

--- a/apps/web/src/views/SessionsView.vue
+++ b/apps/web/src/views/SessionsView.vue
@@ -50,8 +50,12 @@ function doClear() {
   router.push('/')
 }
 
-// 进入页面时刷新各会话的后台运行状态。
-onMounted(() => { sessions.refreshRunning() })
+// 进入页面时先同步引擎磁盘会话（权威源），再刷新各会话的后台运行状态。
+// 只刷新 running 会导致直接从对话页跳进来时列表为空/无摘要。
+onMounted(() => {
+  void sessions.syncFromEngine()
+  sessions.refreshRunning()
+})
 </script>
 <template>
   <div class="page">

--- a/apps/web/src/views/SessionsView.vue
+++ b/apps/web/src/views/SessionsView.vue
@@ -89,6 +89,7 @@ onMounted(() => { sessions.refreshRunning() })
                   <CoomiIcon v-if="m.pinned" name="pin" :size="13" class="pin" />
                   <span class="ttext">{{ m.title }}</span>
                 </span>
+                <span v-if="m.summary" class="rsummary">{{ m.summary }}</span>
                 <span class="rmeta">
                   <span v-if="m.id === session.sessionId" class="badge">当前</span>
                   {{ formatSessionTime(m.updatedAt) }} · {{ m.turns }} 轮
@@ -185,6 +186,11 @@ onMounted(() => { sessions.refreshRunning() })
 @keyframes coomi-rspin { to { transform: rotate(360deg); } }
 .ttext {
   min-width: 0; font-size: 14.5px; font-weight: 550; color: var(--text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+/* 会话摘要（引擎侧推导，供检索与快速识别内容） */
+.rsummary {
+  display: block; margin-top: 3px; font-size: 12px; line-height: 1.5; color: var(--text-3);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .rmeta { display: flex; align-items: center; gap: 6px; margin-top: 2px; font-size: 12px; color: var(--text-3); }


### PR DESCRIPTION
## 内容

本 PR 包含两部分：

### 1. Bug 修复（终端 + Provider 配置）

在 com.coomi.android 包名下，官方 Termux bootstrap 存在包名硬编码，导致：

- **终端打不开**：`exec login` / `bin/bash` 报 `CANNOT LINK EXECUTABLE ... library libandroid-support.so not found`
- **Provider 配置**：自定义 provider 保存时 base_url 为空也会被激活，coomi 加载配置报 `provider 'custom' has no base_url`

修复：
- **TermuxInstaller**：bootstrap 完整性检查（`bin/bash` + `lib/libandroid-support.so` 都存在才算完整，残缺时自动重装）；解压后自动修补脚本中的 com.termux 包名路径
- **CoomiService**：`isBootstrapInstalled()` 增加 `lib/libandroid-support.so` 检查
- **TermuxShellEnvironment**：注入 `LD_LIBRARY_PATH=$PREFIX/lib`（优先级高于 DT_RUNPATH），覆盖 ELF 包名硬编码
- **CoomiConfig**：拒绝保存 base_url 为空的 provider（自定义 provider 必须显式填地址）
- **AuthFragment**：自定义 provider 未填 Base URL 时明确提示

### 2. RAG 会话检索增强（9 个提交）

- 会话 title/summary 本地推导，支持 RAG 检索匹配（旧会话无需迁移）
- 中文分词修复（Unicode 感知），会话搜索支持中文
- 会话摘要多轮采样（首尾双侧 + 中间轮次），长回复尾部关键词不再漏检
- 技术符号分词（B+树、C++、Node.js）与空白差异紧凑匹配
- 检索命中次数加权排序（title×次数×5、summary×次数×3）
- 跨端对拍测试（Rust 单测 + node 脚本共享语料）

基于最新 v1.2.3（c3d2312），cherry-pick 无冲突。