### PR TITLE
fix(tools): use floor_char_boundary in truncate to prevent UTF-8 panic (engine crash on Android)

### DIFF
--- a/apps/coomi-rs/tools/src/lib.rs
+++ b/apps/coomi-rs/tools/src/lib.rs
@@ -1569,7 +1569,11 @@ impl CoreTools {
         if output.len() <= self.max_output {
             return output;
         }
-        output.truncate(self.max_output);
+        // 修复（原 2.0.0 崩溃根因）：String::truncate 要求 new_len 是 UTF-8 字符边界，
+        // 多字节输出（中文等）超长时按字节切会触发 is_char_boundary 断言失败 panic
+        // （本机 coomi.log 反复出现的 tools\src\lib.rs:1557 panic）。
+        // floor_char_boundary 返回 ≤ max_output 的最大字符边界（Rust 1.73+ 稳定，rust-version=1.85 可用）。
+        output.truncate(output.floor_char_boundary(self.max_output));
         output.push_str("\n[output truncated]");
         output
     }


### PR DESCRIPTION
## Problem

`String::truncate` requires `new_len` to be a UTF-8 char boundary. When a tool output exceeds `max_output` bytes and contains multi-byte characters (e.g. Chinese), truncating at `max_output` splits a character and panics:

```
thread tokio-rt-worker panicked at tools\src\lib.rs:1557:16:
assertion failed: self.is_char_boundary(new_len)
```

This crashes the engine repeatedly on Android when any tool returns large multi-byte UTF-8 output.

## Fix

Use `floor_char_boundary` (stable since Rust 1.73, project rust-version is 1.85) to cut at the largest valid char boundary ≤ `max_output`.

## Verification

- Minimal repro: old code panics with the same `is_char_boundary` assertion on a 480KB Chinese string; new code truncates safely.
- `cargo check --workspace` passes (verified with rustc 1.97.1).

Note: `context.rs` already uses `is_char_boundary` correctly when trimming; this aligns `tools::truncate` with that behavior.