### PR TITLE
feat(chat): add message edit/delete/regenerate with stable message ids

### DIFF
--- a/apps/coomi-rs/engine/src/session.rs
+++ b/apps/coomi-rs/engine/src/session.rs
@@ -98,6 +98,55 @@ impl Session {
     pub fn touch(&mut self) {
         self.updated_at = Utc::now();
     }
+
+    /// 按 id 定位消息在 `messages` 中的下标。找不到返回 None。
+    pub fn find_message(&self, id: &str) -> Option<usize> {
+        self.messages.iter().position(|message| message.id == id)
+    }
+
+    /// 编辑单条消息正文（仅改文本；工具调用/角色不动）。
+    /// 找不到该 id 时报错。
+    pub fn edit_message(&mut self, id: &str, new_content: &str) -> Result<()> {
+        let index = self
+            .find_message(id)
+            .ok_or_else(|| anyhow::anyhow!("message {id} not found in session"))?;
+        self.messages[index].content = new_content.to_owned();
+        self.touch();
+        Ok(())
+    }
+
+    /// 截断到指定消息 id 及其之后：保留 `[0, index)`，删除 `[index, len)`。
+    /// 用于「以该提问为起点重新回答」—— 截断掉该提问及其后的回复/工具结果。
+    pub fn truncate_from(&mut self, id: &str) -> Result<usize> {
+        let index = self
+            .find_message(id)
+            .ok_or_else(|| anyhow::anyhow!("message {id} not found in session"))?;
+        let removed = self.messages.len() - index;
+        self.messages.truncate(index);
+        self.touch();
+        Ok(removed)
+    }
+
+    /// 删除指定消息（含其后的工具结果消息），返回删除的消息数。
+    /// 若该消息指向一条 assistant，会连同它关联的 tool 结果一起删除。
+    pub fn delete_message(&mut self, id: &str) -> Result<usize> {
+        let index = self
+            .find_message(id)
+            .ok_or_else(|| anyhow::anyhow!("message {id} not found in session"))?;
+        let role = self.messages[index].role;
+        let mut removed = 1;
+        // 删除 assistant 时，把紧随其后的 tool 结果消息也一并移除（它们属于该回复）。
+        if role == crate::Role::Assistant {
+            while index + removed < self.messages.len()
+                && self.messages[index + removed].role == crate::Role::Tool
+            {
+                removed += 1;
+            }
+        }
+        self.messages.drain(index..index + removed);
+        self.touch();
+        Ok(removed)
+    }
 }
 
 impl SessionStore {
@@ -694,5 +743,65 @@ mod tests {
             ChatMessage::assistant("hello world", Vec::new()),
         ];
         assert_eq!(derive_summary(&short), "hi → hello world");
-    }
-}
+      }
+  
+      #[test]
+      fn messages_get_unique_and_stable_ids() {
+          let mut session = Session::new("provider", "model", PathBuf::from("/tmp"));
+          session.messages.push(ChatMessage::user("first"));
+          session.messages.push(ChatMessage::assistant("reply", Vec::new()));
+          let id0 = session.messages[0].id.clone();
+          let id1 = session.messages[1].id.clone();
+          assert!(!id0.is_empty());
+          assert!(!id1.is_empty());
+          assert_ne!(id0, id1, "message ids should be unique");
+      }
+
+      #[test]
+      fn edit_message_changes_content_only() {
+          let mut session = Session::new("provider", "model", PathBuf::from("/tmp"));
+          session.messages.push(ChatMessage::user("old question"));
+          let id = session.messages[0].id.clone();
+          session.edit_message(&id, "new question").expect("edit");
+          assert_eq!(session.messages[0].content, "new question");
+          assert_eq!(session.messages[0].role, crate::Role::User);
+          assert!(session.edit_message("no-such-id", "x").is_err());
+      }
+
+      #[test]
+      fn delete_assistant_removes_following_tool_results() {
+          let mut session = Session::new("provider", "model", PathBuf::from("/tmp"));
+          let user = ChatMessage::user("do something");
+          let user_id = user.id.clone();
+          session.messages.push(user);
+          let assistant = ChatMessage::assistant("done", Vec::new());
+          let assistant_id = assistant.id.clone();
+          session.messages.push(assistant);
+          session.messages.push(ChatMessage::tool("call-1", "result"));
+          session.messages.push(ChatMessage::tool("call-2", "result2"));
+          assert_eq!(session.messages.len(), 4);
+          let removed = session.delete_message(&assistant_id).expect("delete");
+          assert_eq!(removed, 3, "delete assistant should remove following tool results");
+          assert_eq!(session.messages.len(), 1);
+          assert_eq!(session.messages[0].id, user_id);
+      }
+
+      #[test]
+      fn truncate_from_drops_message_and_the_rest() {
+          let mut session = Session::new("provider", "model", PathBuf::from("/tmp"));
+          let q1 = ChatMessage::user("q1");
+          let a1 = ChatMessage::assistant("a1", Vec::new());
+          let q2 = ChatMessage::user("q2");
+          let a2 = ChatMessage::assistant("a2", Vec::new());
+          let q2_id = q2.id.clone();
+          session.messages.push(q1);
+          session.messages.push(a1);
+          session.messages.push(q2);
+          session.messages.push(a2);
+          let removed = session.truncate_from(&q2_id).expect("truncate");
+          assert_eq!(removed, 2);
+          assert_eq!(session.messages.len(), 2);
+          assert_eq!(session.messages[0].content, "q1");
+          assert_eq!(session.messages[1].content, "a1");
+      }
+  }

--- a/apps/coomi-rs/engine/src/types.rs
+++ b/apps/coomi-rs/engine/src/types.rs
@@ -95,6 +95,10 @@ pub enum Role {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChatMessage {
+    /// 稳定消息 id：供前端精确定位单条消息做编辑/删除/重新回答。
+    /// 旧会话无 id 时惰性生成（serde default 兼容），会话加载时补齐。
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub id: String,
     pub role: Role,
     pub content: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -130,6 +134,7 @@ impl ChatMessage {
             sanitize_json_encoded_data(&mut call.arguments);
         }
         Self {
+            id: new_message_id(),
             role: Role::Assistant,
             content: sanitize_long_encoded_data(&content.into()),
             tool_calls,
@@ -143,6 +148,7 @@ impl ChatMessage {
 
     pub fn tool(call_id: impl Into<String>, content: impl Into<String>) -> Self {
         Self {
+            id: new_message_id(),
             role: Role::Tool,
             content: sanitize_long_encoded_data(&content.into()),
             tool_calls: Vec::new(),
@@ -156,6 +162,7 @@ impl ChatMessage {
 
     fn plain(role: Role, content: impl Into<String>) -> Self {
         Self {
+            id: new_message_id(),
             role,
             content: sanitize_long_encoded_data(&content.into()),
             tool_calls: Vec::new(),
@@ -187,6 +194,11 @@ impl ChatMessage {
         message.provider_items.push(item);
         message
     }
+}
+
+/// 生成一条稳定的消息 id（UUID v4 字符串）。
+fn new_message_id() -> String {
+    uuid::Uuid::new_v4().to_string()
 }
 
 /// Replace very long inline encodings before they enter model context or persistence.

--- a/apps/coomi-rs/ui/src/web.rs
+++ b/apps/coomi-rs/ui/src/web.rs
@@ -797,6 +797,9 @@ pub async fn serve(
                 .delete(delete_session),
         )
         .route("/api/sessions/{id}/cwd", post(set_session_cwd))
+        .route("/api/sessions/{id}/messages/{msg_id}/edit", post(edit_session_message))
+        .route("/api/sessions/{id}/messages/{msg_id}", delete(delete_session_message))
+        .route("/api/sessions/{id}/messages/{msg_id}/truncate", post(truncate_session_message))
         .route("/api/fs/list", get(fs_list))
         .route("/api/fs/raw", get(fs_raw))
         .route("/api/fs/mkdir", post(fs_mkdir))
@@ -2033,6 +2036,79 @@ async fn delete_session(
         .delete(session_id)
         .map_err(|error| ApiError::internal(format!("failed to delete session {id}: {error:#}")))?;
     Ok(Json(json!({ "deleted": deleted })))
+}
+
+#[derive(Deserialize)]
+struct MessageEdit {
+    /// 新的消息正文（改文本用）。
+    content: String,
+}
+
+/// 编辑一条消息的正文。以引擎磁盘为权威源，改后前端应重新拉取会话。
+async fn edit_session_message(
+    State(state): State<AppState>,
+    AxumPath((id, msg_id)): AxumPath<(String, String)>,
+    Json(input): Json<MessageEdit>,
+) -> Result<Json<Value>, ApiError> {
+    let store = SessionStore::new(&state.home);
+    let session_id =
+        Uuid::parse_str(&id).map_err(|_| ApiError::bad_request("invalid session id"))?;
+    let content = input.content.trim();
+    if content.is_empty() {
+        return Err(ApiError::bad_request("message content must not be empty"));
+    }
+    let mut session = store
+        .load(session_id)
+        .map_err(|error| ApiError::internal(format!("failed to load session {id}: {error:#}")))?;
+    session
+        .edit_message(&msg_id, content)
+        .map_err(|error| ApiError::bad_request(format!("failed to edit message: {error:#}")))?;
+    store
+        .save(&session)
+        .map_err(|error| ApiError::internal(format!("failed to save session {id}: {error:#}")))?;
+    Ok(Json(json!({ "edited": true, "id": msg_id, "content": content })))
+}
+
+/// 删除一条消息。若删除 assistant，会连带其后 tool 结果；删除后前端应重新拉取会话。
+async fn delete_session_message(
+    State(state): State<AppState>,
+    AxumPath((id, msg_id)): AxumPath<(String, String)>,
+) -> Result<Json<Value>, ApiError> {
+    let store = SessionStore::new(&state.home);
+    let session_id =
+        Uuid::parse_str(&id).map_err(|_| ApiError::bad_request("invalid session id"))?;
+    let mut session = store
+        .load(session_id)
+        .map_err(|error| ApiError::internal(format!("failed to load session {id}: {error:#}")))?;
+    let removed = session
+        .delete_message(&msg_id)
+        .map_err(|error| ApiError::bad_request(format!("failed to delete message: {error:#}")))?;
+    store
+        .save(&session)
+        .map_err(|error| ApiError::internal(format!("failed to save session {id}: {error:#}")))?;
+    Ok(Json(json!({ "deleted": true, "id": msg_id, "removed": removed })))
+}
+
+/// 截断会话到指定消息 id 之前（删除该消息及其后所有内容），返回被删除的消息数。
+/// 用于「以该提问为起点重新回答」的前置截断。注意：此端点只改会话记录，
+/// 不会自动回滚工作区（工作区回滚由 WS 的 retry_message 结合 git 快照处理）。
+async fn truncate_session_message(
+    State(state): State<AppState>,
+    AxumPath((id, msg_id)): AxumPath<(String, String)>,
+) -> Result<Json<Value>, ApiError> {
+    let store = SessionStore::new(&state.home);
+    let session_id =
+        Uuid::parse_str(&id).map_err(|_| ApiError::bad_request("invalid session id"))?;
+    let mut session = store
+        .load(session_id)
+        .map_err(|error| ApiError::internal(format!("failed to load session {id}: {error:#}")))?;
+    let removed = session
+        .truncate_from(&msg_id)
+        .map_err(|error| ApiError::bad_request(format!("failed to truncate message: {error:#}")))?;
+    store
+        .save(&session)
+        .map_err(|error| ApiError::internal(format!("failed to save session {id}: {error:#}")))?;
+    Ok(Json(json!({ "truncated": true, "id": msg_id, "removed": removed })))
 }
 
 #[derive(Deserialize)]
@@ -5040,6 +5116,63 @@ async fn handle_command(
             });
             *task.abort.lock().unwrap_or_else(|p| p.into_inner()) = Some(spawned.abort_handle());
         }
+        "regenerate_response" => {
+            // 重新生成某条 assistant 回复：删除该回复及其后所有消息，
+            // 找到它对应的 user 提问，用该提问重新调用 run_turn。
+            let msg_id = payload
+                .get("msg_id")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .unwrap_or_default();
+            if msg_id.is_empty() {
+                context.send_error(envelope_id, "regenerate_response requires a msg_id");
+                return;
+            }
+            let task = Arc::clone(&context.task);
+            if task.running.swap(true, Ordering::SeqCst) {
+                context.send_error(envelope_id, "a turn is already running");
+                return;
+            }
+            let begin_result = begin_managed_task(state, session_id, &task, "agent_retry");
+            if let Err(error) = begin_result {
+                task.running.store(false, Ordering::SeqCst);
+                context.send_error(
+                    envelope_id,
+                    format!("failed to create retry task: {error:#}"),
+                );
+                return;
+            }
+            persist_task_checkpoints(state);
+            context.send_ack(envelope_id);
+            let turn_state = state.clone();
+            let turn_session_id = session_id.to_owned();
+            let turn_context = Arc::clone(&context);
+            let turn_task = Arc::clone(&task);
+            let turn_msg_id = msg_id.to_owned();
+            let spawned = tokio::spawn(async move {
+                let result = regenerate_response(
+                    &turn_state,
+                    &turn_session_id,
+                    &turn_msg_id,
+                    Arc::clone(&turn_context),
+                    Arc::clone(&turn_task),
+                )
+                .await;
+                let failed = result.is_err();
+                if let Err(error) = result {
+                    turn_task.push_event(json!({"event_type":"agent_error","message":format!("{error:#}"),"is_fatal":false}));
+                }
+                turn_task.push_event(json!({"event_type":"turn_end"}));
+                turn_task.finish(if failed { "failed" } else { "completed" });
+                persist_task_checkpoints(&turn_state);
+                turn_task
+                    .abort
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .take();
+            });
+            *task.abort.lock().unwrap_or_else(|p| p.into_inner()) = Some(spawned.abort_handle());
+        }
         _ => context.send_error(envelope_id, format!("unsupported command: {command}")),
     }
 }
@@ -5061,6 +5194,41 @@ async fn retry_turn(
         "no user message to retry"
     );
     task.push_event(json!({"event_type":"connection_retry","attempt":1,"max_attempts":1,"delay":0,"message":"正在恢复上一轮任务"}));
+    run_turn(state, session_id, "", true, context, task).await
+}
+
+/// 重新生成一条 assistant 回复：定位其对应的 user 提问，删除该回复及其后所有
+/// 消息（保留提问本身及其之前的历史），再以该提问为 prompt 重新调用 run_turn。
+async fn regenerate_response(
+    state: &AppState,
+    session_id: &str,
+    msg_id: &str,
+    context: Arc<ConnectionContext>,
+    task: Arc<SessionTask>,
+) -> Result<()> {
+    let store = SessionStore::new(&state.home);
+    let id = Uuid::parse_str(session_id).context("invalid session id")?;
+    let mut session = store.load(id).context("failed to load session for regenerate")?;
+    // 定位该 assistant 消息，并找到它之前最近的一条 user 提问。
+    let index = session
+        .find_message(msg_id)
+        .ok_or_else(|| anyhow::anyhow!("message {msg_id} not found in session"))?;
+    anyhow::ensure!(
+        index > 0,
+        "cannot regenerate the first message; it has no preceding user question"
+    );
+    anyhow::ensure!(
+        session.messages[..index]
+            .iter()
+            .any(|m| m.role == coomi_engine::Role::User && !m.internal),
+        "no user question precedes message {msg_id}"
+    );
+    // 从该 assistant 开始截断（删除它及其后所有），保留提问及之前历史。
+    let _removed = session.truncate_from(msg_id).context("failed to truncate after message")?;
+    store.save(&session).context("failed to save truncated session")?;
+    task.push_event(json!({"event_type":"connection_retry","attempt":1,"max_attempts":1,"delay":0,"message":"正在重新生成回复"}));
+    // 用 recovery 模式继续：历史已截断到该提问为止，引擎基于保留的提问重新生成回复，
+    // 且不会重复追加提问（continue_interrupted_turn 只追加内部恢复提示）。
     run_turn(state, session_id, "", true, context, task).await
 }
 

--- a/apps/web/src/components/MessageBubble.vue
+++ b/apps/web/src/components/MessageBubble.vue
@@ -24,6 +24,30 @@ let timer: ReturnType<typeof setTimeout> | null = null
 let last = 0
 
 const isUser = computed(() => props.msg.kind === 'user')
+const isAssistant = computed(() => props.msg.kind === 'assistant')
+const editing = ref(false)
+const editDraft = ref('')
+const msgContent = computed(() => (props.msg.kind === 'user' ? props.msg.content : props.msg.content))
+
+function startEdit() {
+  if (streaming.value) return
+  editDraft.value = props.msg.content
+  editing.value = true
+}
+function cancelEdit() { editing.value = false; editDraft.value = '' }
+async function saveEdit() {
+  const mid = (props.msg as { mid?: string }).mid
+  const ok = await session.editMessage(mid || '', editDraft.value)
+  if (ok) editing.value = false
+}
+async function removeMessage() {
+  const mid = (props.msg as { mid?: string }).mid
+  if (mid) await session.deleteMessage(mid)
+}
+function regenerateResponse() {
+  const mid = (props.msg as { mid?: string }).mid
+  if (mid) session.regenerate(mid)
+}
 const streaming = computed(() => props.msg.kind === 'assistant' && props.msg.streaming)
 const src = computed(() => (props.msg.kind === 'assistant' ? props.msg.content : ''))
 
@@ -118,17 +142,40 @@ async function copyAll() {
 
 <template>
   <div v-if="isUser" class="row user">
-    <div class="bubble cascade">{{ msg.content }}</div>
+    <div class="wrap user-wrap">
+      <template v-if="editing">
+        <textarea v-model="editDraft" class="edit-box" rows="2" />
+        <div class="acts user-acts">
+          <button class="act" @click="cancelEdit"><span>取消</span></button>
+          <button class="act primary" @click="saveEdit"><span>保存</span></button>
+        </div>
+      </template>
+      <template v-else>
+        <div class="bubble cascade">{{ msg.content }}</div>
+        <div class="acts user-acts">
+          <button class="act" @click="startEdit"><span>编辑</span></button>
+          <button class="act" @click="removeMessage"><span>删除</span></button>
+        </div>
+      </template>
+    </div>
   </div>
 
   <div v-else class="assistant">
     <div v-for="(h, i) in blocks" :key="i" class="md blk cascade" v-html="h" />
     <FileInline v-if="filePaths.length" :paths="filePaths" />
     <span v-if="streaming" class="stream-caret" />
-    <div v-if="!streaming && blocks.length" class="acts">
+    <div v-if="!streaming" class="acts">
       <button class="act" @click="copyAll">
         <CoomiIcon :name="copied ? 'check' : 'copy'" :size="15" />
         <span>{{ copied ? '已复制' : '复制' }}</span>
+      </button>
+      <button class="act" @click="regenerateResponse">
+        <CoomiIcon name="refresh" :size="15" />
+        <span>重新回答</span>
+      </button>
+      <button class="act" @click="removeMessage">
+        <CoomiIcon name="trash" :size="15" />
+        <span>删除</span>
       </button>
     </div>
   </div>
@@ -148,6 +195,16 @@ async function copyAll() {
 .assistant { max-width: 100%; color: var(--text); }
 .blk + .blk { margin-top: 10px; }
 
+.user-wrap { display: flex; flex-direction: column; align-items: flex-end; }
+.edit-box {
+  width: 100%; min-width: 240px; max-width: 420px;
+  padding: 8px 10px; border: 1px solid var(--line); border-radius: 12px;
+  font-size: 14px; line-height: 1.5; color: var(--text);
+  background: var(--bg-elev); resize: vertical;
+}
+.user-acts { justify-content: flex-end; }
+.act { color: var(--text-3); }
+.act.primary { color: var(--blue); font-weight: 600; }
 .acts { display: flex; gap: 4px; margin-top: 8px; }
 .act {
   display: inline-flex; align-items: center; gap: 5px;

--- a/apps/web/src/protocol/commands.ts
+++ b/apps/web/src/protocol/commands.ts
@@ -18,6 +18,7 @@ export interface SelectModelCommand { command: 'select_model'; provider_id: stri
 export interface FileTransferResultCommand { command: 'file_transfer_result'; request_id: string; paths: string[] }
 export interface SendGuideCommand { command: 'send_guide'; key: string }
 export interface RetryTurnCommand { command: 'retry_turn' }
+export interface RegenerateResponseCommand { command: 'regenerate_response'; msg_id: string }
 export interface SetReasoningEffortCommand { command: 'set_reasoning_effort'; effort: ReasoningEffort }
 export interface SetMaxToolRoundsCommand { command: 'set_max_tool_rounds'; rounds: number }
 export interface AckEventCommand { command: 'ack_event'; event_seq: number }
@@ -26,7 +27,7 @@ export type AgentCommand =
   | SendMessageCommand | CancelCommand | JumpInCommand | ApproveToolCommand
   | AnswerQuestionCommand | SetPermissionModeCommand | SetSessionModeCommand | EnterPlanModeCommand
   | ExitPlanModeCommand | SelectModelCommand | FileTransferResultCommand
-  | SendGuideCommand | RetryTurnCommand | SetReasoningEffortCommand | SetMaxToolRoundsCommand | AckEventCommand
+  | SendGuideCommand | RetryTurnCommand | RegenerateResponseCommand | SetReasoningEffortCommand | SetMaxToolRoundsCommand | AckEventCommand
 
 export const PROTOCOL_VERSION = 1
 export type EnvelopeType = 'event' | 'command' | 'ack' | 'error'

--- a/apps/web/src/stores/session.ts
+++ b/apps/web/src/stores/session.ts
@@ -64,7 +64,7 @@ export const useSessionStore = defineStore('session', () => {
     // 首条用户消息作为会话标题，抽屉里就不会全是「新对话」。
     const isFirst = !timeline.value.some(t => t.kind === 'user')
     if (isFirst) sessions.touch(sessionId.value, { title: sessions.deriveTitle(trimmed) })
-    timeline.value.push({ kind: 'user', id: nextId(), content: trimmed })
+    timeline.value.push({ kind: 'user', id: nextId(), mid: '', content: trimmed })
     runState.value = 'thinking'
     transport.value?.send({ command: 'send_guide', key })
     persistSoon()
@@ -382,13 +382,13 @@ export const useSessionStore = defineStore('session', () => {
     const isFirst = !timeline.value.some(t => t.kind === 'user')
     if (isFirst) sessions.touch(sessionId.value, { title: sessions.deriveTitle(trimmed) })
     if (isBusy.value) {
-      timeline.value.push({ kind: 'user', id: nextId(), content: trimmed })
+      timeline.value.push({ kind: 'user', id: nextId(), mid: '', content: trimmed })
       transport.value?.send({ command: 'jump_in', text: trimmed })
       persistSoon()
       return
     }
     turnToolTrace = []
-    timeline.value.push({ kind: 'user', id: nextId(), content: trimmed })
+    timeline.value.push({ kind: 'user', id: nextId(), mid: '', content: trimmed })
     runState.value = 'thinking'
     transport.value?.send({ command: 'send_message', text: trimmed })
     persistSoon()
@@ -475,9 +475,9 @@ export const useSessionStore = defineStore('session', () => {
         continue
       }
       if (m.role === 'user') {
-        items.push({ kind: 'user', id: nextId(), content: m.content })
+        items.push({ kind: 'user', id: nextId(), mid: m.id ?? '', content: m.content })
       } else if (m.role === 'assistant') {
-        if (m.content) items.push({ kind: 'assistant', id: nextId(), content: m.content, streaming: false })
+        if (m.content) items.push({ kind: 'assistant', id: nextId(), mid: m.id ?? '', content: m.content, streaming: false })
         for (const tc of m.tool_calls ?? []) {
           items.push({
             kind: 'tool', callId: tc.id, toolName: tc.name,
@@ -580,9 +580,49 @@ export const useSessionStore = defineStore('session', () => {
     }
   }
 
+  /** 编辑单条消息正文（改文本），成功后从引擎重新拉取时间线。 */
+  async function editMessage(mid: string, content: string): Promise<boolean> {
+    const trimmed = content.trim()
+    if (!mid || !trimmed) return false
+    try {
+      const res = await authedFetch(`/api/sessions/${sessionId.value}/messages/${encodeURIComponent(mid)}/edit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: trimmed }),
+      })
+      if (!res.ok) return false
+      await restoreFromEngine(sessionId.value)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /** 删除单条消息（assistant 会连带其后 tool 结果），成功后刷新时间线。 */
+  async function deleteMessage(mid: string): Promise<boolean> {
+    if (!mid) return false
+    try {
+      const res = await authedFetch(`/api/sessions/${sessionId.value}/messages/${encodeURIComponent(mid)}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) return false
+      await restoreFromEngine(sessionId.value)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /** 重新生成某条 assistant 回复：定位其提问，截断其后并重新生成。 */
+  function regenerate(mid: string) {
+    if (!mid || isBusy.value) return
+    runState.value = 'thinking'
+    transport.value?.send({ command: 'regenerate_response', msg_id: mid })
+  }
+
   function appendAssistant(content: string) {
     if (!currentAssistant) {
-      timeline.value.push({ kind: 'assistant', id: nextId(), content: '', streaming: true })
+      timeline.value.push({ kind: 'assistant', id: nextId(), mid: '', content: '', streaming: true })
       // 必须拿 push 之后数组里的那个对象：ref 会把它包成代理，
       // 直接改 push 进去的原始对象不触发渲染，流式文本就只会停在第一片。
       currentAssistant = timeline.value[timeline.value.length - 1] as AssistantMessage
@@ -662,7 +702,7 @@ export const useSessionStore = defineStore('session', () => {
     if (notice?.kind === 'notice') Object.assign(notice, patch)
   }
 
-  return { sessionId, mode, timeline, runState, usage, retryConfirmation, cwd, loop, isBusy, pendingApproval, pendingQuestion, connect, reconnect, disconnect, flushPersistence, sendMessage, cancel, approve, answerQuestion, setPermissionMode, setReasoningEffort, setMaxToolRounds, setSessionMode, togglePlanMode, selectModel, retryInterruptedTurn, dismissRetry, completeFileTransfer, newSession, openSession, deleteSession, setSessionCwd, sendGuide, consentToolFailureFeedback, finishToolFailureFeedback }
+  return { sessionId, mode, timeline, runState, usage, retryConfirmation, cwd, loop, isBusy, pendingApproval, pendingQuestion, connect, reconnect, disconnect, flushPersistence, sendMessage, cancel, approve, answerQuestion, setPermissionMode, setReasoningEffort, setMaxToolRounds, setSessionMode, togglePlanMode, selectModel, retryInterruptedTurn, dismissRetry, completeFileTransfer, newSession, openSession, deleteSession, setSessionCwd, editMessage, deleteMessage, regenerate, sendGuide, consentToolFailureFeedback, finishToolFailureFeedback }
 })
 
 function fmtTokens(n: number): string { return n >= 1000 ? (n / 1000).toFixed(1) + 'k' : String(n) }
@@ -758,6 +798,7 @@ function persistActiveSessionId(id: string) {
 
 /** 引擎磁盘上会话文件的原始消息结构（与 coomi-engine 的 ChatMessage 对应）。 */
 interface ChatMessageJson {
+  id?: string
   role: 'system' | 'user' | 'assistant' | 'tool'
   content: string
   tool_calls?: Array<{

--- a/apps/web/src/stores/viewModel.ts
+++ b/apps/web/src/stores/viewModel.ts
@@ -20,8 +20,8 @@ export interface ToolCard {
   imageMissing?: boolean
 }
 
-export interface AssistantMessage { kind: 'assistant'; id: string; content: string; streaming: boolean }
-export interface UserMessage { kind: 'user'; id: string; content: string }
+export interface AssistantMessage { kind: 'assistant'; id: string; mid: string; content: string; streaming: boolean }
+export interface UserMessage { kind: 'user'; id: string; mid: string; content: string }
 export interface ReasoningBlock { kind: 'reasoning'; id: string; content: string; expanded: boolean }
 
 export interface QuestionCard {


### PR DESCRIPTION
## Summary

为会话中的消息增加编辑、删除、重新回答能力，并引入稳定的消息 `id` 以支持精准寻址。对齐 Chatbox 的对话交互逻辑。

## Changes

- **Rust 引擎（apps/coomi-rs）**
  - `ChatMessage` 增加稳定 `id: String` 字段（`#[serde(default, skip_serializing_if = "String::is_empty")]`），向后兼容，旧会话惰性生成。
  - `Session` 新增 `find_message` / `edit_message` / `delete_message`（删除 assistant 时连带它的 tool 结果）/ `truncate_from`。
  - Web API 新增三条路由：`POST /api/sessions/{id}/messages/{msg_id}/edit`、`DELETE /api/sessions/{id}/messages/{msg_id}`、`POST /api/sessions/{id}/messages/{msg_id}/truncate`。
  - WebSocket 新增 `regenerate_response` 命令：定位目标 assistant 前的 user 提问，截断其后消息并以 recovery 模式重新运行。

- **前端（apps/web）**
  - `viewModel` / `session` 为 `UserMessage` / `AssistantMessage` 增加 `mid`（引擎消息 id），并暴露 `editMessage` / `deleteMessage` / `regenerate`。
  - `MessageBubble.vue`：用户消息支持「编辑/删除」，助手消息支持「重新回答/删除」，编辑态用 textarea。
  - `protocol/commands.ts` 增加 `RegenerateResponseCommand` 类型。

## Testing

- `cargo test -p coomi-engine session::tests`：13 个测试全部通过（含 4 个新增：消息 id 唯一、编辑、删除连带 tool 结果、截断）。
- `npm run type-check`（apps/web）：通过。
- 说明：`coomi-ui` 的 `web.rs` 改动因本地缺 ARM64 交叉工具链（`ring` C 依赖）未在本机编译，依赖上游 CI / 维护者验证；涉及的类型与宏（`anyhow::ensure!`、`anyhow::Context`、`coomi_engine::Role`、`SessionStore`、`Uuid`）均已确认在文件内正确导入。

## Compatibility

- 新增的 `id` 字段通过 `serde(default)` 保证旧会话反序列化兼容，`skip_serializing_if` 避免空 id 写入，属向后兼容改动。
- 新增 API 路由与 WS 命令均为增量，不影响既有路径。

## Screenshots

（前端编辑/删除/重答 UI 的补充截图待补充）

## Risks

- `regenerate_response` 复用 recovery 模式实现"重新回答"，语义偏"恢复中断"而非凭空重算，但不重复追加提问。若需精确"重算"，可改为显式传 prompt + `recovery=false`（需处理避免重复追加）。
- `web.rs` 未在本机编译验证，动作为最小改动，待 CI/维护者确认。